### PR TITLE
Add HTMX at search

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,8 @@ func main() {
 	r.Use(securityHeaders)
 
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { render("home", w, nil) })
-	r.HandleFunc("/search", searchHandler).Methods("GET")
+	r.HandleFunc("/search", fullSearchHandler).Methods("GET")
+	r.HandleFunc("/form_search", formSearchHandler).Methods("POST")
 	r.HandleFunc("/{id}-lyrics", lyricsHandler)
 	r.HandleFunc("/images/{filename}.{ext}", proxyHandler)
 	r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir("static"))))

--- a/search.go
+++ b/search.go
@@ -34,8 +34,7 @@ type renderVars struct {
 	Sections sections
 }
 
-func searchHandler(w http.ResponseWriter, r *http.Request) {
-	query := r.URL.Query().Get("q")
+func searchHandler(query string, w http.ResponseWriter, r *http.Request) renderVars {
 	url := fmt.Sprintf(`https://genius.com/api/search/multi?q=%s`, url.QueryEscape(query))
 
 	res, err := sendRequest(url)
@@ -55,7 +54,19 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 	d := json.NewDecoder(res.Body)
 	d.Decode(&data)
 
-	vars := renderVars{query, data.Response.Sections}
+	return renderVars{query, data.Response.Sections}
 
+	// render("search", w, vars)
+}
+
+func fullSearchHandler(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query().Get("q")
+	vars := searchHandler(query, w, r)
 	render("search", w, vars)
+}
+
+func formSearchHandler(w http.ResponseWriter, r *http.Request) {
+	query := r.FormValue("q")
+	vars := searchHandler(query, w, r)
+	render("search_partial", w, vars)
 }

--- a/utils.go
+++ b/utils.go
@@ -47,7 +47,9 @@ func write(w http.ResponseWriter, status int, data []byte) {
 
 func securityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		csp := "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self'; object-src 'none'"
+		csp := "style-src 'self'; img-src 'self'; object-src 'none'"
+		// This is CSP interrupts the HTMX and other JS requests
+		// SO I am disabling it for now
 		w.Header().Add("content-security-policy", csp)
 		w.Header().Add("referrer-policy", "no-referrer")
 		w.Header().Add("x-content-type-options", "nosniff")
@@ -67,7 +69,7 @@ func getTemplates(templates ...string) []string {
 func render(n string, w http.ResponseWriter, data interface{}) {
 	w.Header().Set("content-type", "text/html")
 	t := template.New(n + ".tmpl").Funcs(template.FuncMap{"extractURL": extractURL})
-	t, err := t.ParseFiles(getTemplates(n, "navbar", "footer")...)
+	t, err := t.ParseFiles(getTemplates(n, "navbar", "footer", "head")...)
 	if err != nil {
 		logger.Errorln(err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -104,7 +106,6 @@ func sendRequest(u string) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-
 
 	req := &http.Request{
 		Method: http.MethodGet,

--- a/views/head.tmpl
+++ b/views/head.tmpl
@@ -1,0 +1,9 @@
+{{define "head"}}
+    <head>
+		<title>dumb</title>
+		<meta charset="utf-8" />
+		<link rel="stylesheet" type="text/css" href="/static/style.css" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script src="https://unpkg.com/htmx.org@1.9.7"></script>
+	</head>
+{{end}}

--- a/views/home.tmpl
+++ b/views/home.tmpl
@@ -1,11 +1,6 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<title>dumb</title>
-		<meta charset="utf-8" />
-		<link rel="stylesheet" type="text/css" href="/static/style.css" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-	</head>
+	{{template "head"}}
 	<body>
 		<main id="app">
 			{{template "navbar"}}
@@ -15,8 +10,11 @@
 					<p>An alternative frontend for genius.com</p>
 				</div>
 				<form method="GET" action="/search">
-					<input type="text" name="q" id="search-input" placeholder="Search..." />
+					<input hx-post="/form_search" hx-target="#results" hx-trigger="keyup changed delay:0.1s" type="text" name="q" id="search-input" placeholder="Search..." />
 				</form>
+				<div id="results">
+					
+				</div>
 
 			</div>
 			{{template "footer"}}

--- a/views/search_partial.tmpl
+++ b/views/search_partial.tmpl
@@ -1,0 +1,16 @@
+<div id="search-results">
+{{range .Sections}}
+    {{if eq .Type "song"}}
+        <h1>Songs</h1>
+        {{range .Hits}}
+            <a id="search-item" href="{{.Result.Path}}">
+                <img src="{{extractURL .Result.Thumbnail}}"/>
+                <div>
+                    <span>{{.Result.ArtistNames}}</span>
+                    <h2>{{.Result.Title}}</h2>
+                </div>
+            </a>
+        {{end}}
+    {{end}}
+{{end}}
+</div>


### PR DESCRIPTION
Regarding #44 

This commit adds htmx to the main search bar at the home page, just for a test....
this is how it looks:

https://github.com/rramiachraf/dumb/assets/78465651/3cf2bf81-29fc-4c24-b1d6-fae21fd948bc

However, here are some things I had to do to get this and some optimizations:

1. I added a main search route and two subsidiaries to it called `/search`, for normal search and `/form_search` that only works with post requests
2. Had to add a `search_partial.tmpl` that only had the styled div of the search results
3. {MAIN} I had to remove the  `default-src 'self'; script-src 'self';` from the CSP... I am not sure where the CSP is being used, so I am sorry if it was neccessay, please let me know

Other than that, hopefully, this is a nice demo :)