### PR TITLE
Added ARM64 as a supported container image architecture

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,18 +1,83 @@
-name: Build container image
+name: Build and publish container images
+
 on:
-  push:
-    branches:
-      - main
+  push: { branches: [ main ] }
+
+permissions:
+  packages: write
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    outputs:
+      commit: ${{ steps.metadata.outputs.commit }}
+    strategy:
+      matrix:
+        architecture: [ amd64, arm64v8 ]
+        include: 
+          - architecture: amd64
+            platform: linux/amd64
+          - architecture: arm64v8
+            platform: linux/arm64
     steps:
-       - uses: actions/checkout@v4
-       - uses: docker/login-action@v3
-         with:
-           registry: ghcr.io
-           username: ${{ github.actor }}
-           password: ${{ secrets.GITHUB_TOKEN }}
-       - run: docker buildx build . -t ghcr.io/rramiachraf/dumb:latest
-       - run: docker push ghcr.io/rramiachraf/dumb:latest
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Obtain project metadata 
+        id: metadata
+        run: echo "commit=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+  
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        uses: docker/metadata-action@v5
+        id: image-metadata
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ matrix.architecture }}-${{ steps.metadata.outputs.commit }},enable={{is_default_branch}}
+            type=raw,value=${{ matrix.architecture }},enable={{is_default_branch}}
+
+      - name: Build and push platform specific images
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          tags: ${{ steps.image-metadata.outputs.tags }}
+
+  merge:
+    runs-on: ubuntu-20.04
+    needs: [ build ]
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}
+      COMMIT: ${{ needs.build.outputs.commit }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate manifest for multi-arch images from source manifests
+        run: |
+          docker buildx imagetools create \
+            --tag ${IMAGE}:${COMMIT} ${IMAGE}:{amd64,arm64v8}-${COMMIT}
+          docker buildx imagetools create \
+            --tag ${IMAGE}:latest ${IMAGE}:{amd64,arm64v8}


### PR DESCRIPTION
I have some ARM64 nodes on my infrastructure and felt like it should run on those as well. So I made a repo which would compile the image for this architecure... Decided it would be better to add to the upstream repo instead so I just yoinked and modified what I made on said repo.

https://github.com/kankerdev/dumb/blob/da0f7686f25d8c15a7538ad167aa4bda3f0a905b/.github/workflows/build.yml

I might come back to this repo at some point to add cross-compilation to the build process instead as it would reduce runner time but this should work just fine for now.