### PR TITLE
fix: don't error when clicks dispatch on annotation link child

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -26,7 +26,7 @@ window.addEventListener("load", () => {
 function getAnnotation(e) {
 	e.preventDefault()
 	//document.querySelector('.annotation')?.remove()
-	const link = e.target.parentElement
+	const link = e.currentTarget
 	const uri = link.getAttribute("href")
 	const presentAnnotation = link.nextElementSibling.matches(".annotation") && link.nextElementSibling
 	if (presentAnnotation) {


### PR DESCRIPTION
Reproducible by clicking on lyrics in `<i>` or `<b>` tags.